### PR TITLE
Fix module name in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module tget
+module github.com/sweetbbak/tget
 
 go 1.21.7
 


### PR DESCRIPTION
It is to fix this error when doing go install:

```
go: github.com/sweetbbak/tget@latest: version constraints conflict:
	github.com/sweetbbak/tget@v0.0.0-20240302062246-ed67c7a67787: parsing go.mod:
	module declares its path as: tget
	       but was required as: github.com/sweetbbak/tget
```